### PR TITLE
exclude package name

### DIFF
--- a/autoload/unite/sources/haskellimport.vim
+++ b/autoload/unite/sources/haskellimport.vim
@@ -26,6 +26,7 @@ endfunction
 function! s:remove_verbose(output)
   let l:output = substitute(a:output, '^.*= ANSWERS =\n', '', '')
   let l:output = substitute(l:output, '^No results found\n', '', '')
+  let l:output = substitute(l:output, 'package.\{-}\n', '', 'g')
   let l:output = substitute(l:output, '  -- \(\a\+\(+\a\+\)*\)*', '', 'g')
   return l:output
 endfunction


### PR DESCRIPTION
I think that `package something` should be excluded. Try filtering with `vector` and you might see tons of packages name of which are something like *vector-something*, but you would not intend to import.