### PR TITLE
escape backslash and double quote, also care for `Closing bracket expected` (fix #4)

### DIFF
--- a/autoload/unite/sources/haskellimport.vim
+++ b/autoload/unite/sources/haskellimport.vim
@@ -10,12 +10,12 @@ let s:unite_source = {
 
 function! s:unite_source.gather_candidates(args, context)
   return map(
-        \ split(s:remove_verbose(unite#util#system('hoogle --verbose "' . a:context.input . '"')), "\n"),
+        \ split(s:remove_verbose(unite#util#system('hoogle --verbose "' . escape(a:context.input, '\"') . '"')), "\n"),
         \ '{
         \ "word": v:val,
         \ "source": "haskellimport",
         \ "kind": "command",
-        \ "action__command": printf("silent Haskellimport \"%s\"", v:val),
+        \ "action__command": printf("silent Haskellimport \"%s\"", escape(v:val, "\\\"")),
         \ }')
 endfunction
 

--- a/autoload/unite/sources/haskellimport.vim
+++ b/autoload/unite/sources/haskellimport.vim
@@ -8,9 +8,17 @@ let s:unite_source = {
       \ 'required_pattern_length': 2,
       \ }
 
+function! s:hoogle(input)
+  return s:remove_verbose(unite#util#system('hoogle --verbose "' . escape(a:input, '\"') . '"'))
+endfunction
+
 function! s:unite_source.gather_candidates(args, context)
+  let result = s:hoogle(a:context.input)
+  if result =~# '^Parse error.*Closing bracket expected'
+    let result = s:hoogle(substitute(a:context.input, '(', '', ''))
+  endif
   return map(
-        \ split(s:remove_verbose(unite#util#system('hoogle --verbose "' . escape(a:context.input, '\"') . '"')), "\n"),
+        \ split(result, "\n"),
         \ '{
         \ "word": v:val,
         \ "source": "haskellimport",


### PR DESCRIPTION
By escaping the backslash for the external command and the `Haskellimport` command, this pull request enables us to
```
import Data.List ((\\))
  with inputs
  \\
  (\   // ← Closing bracket expected
  (\\   // ← Closing bracket expected
```
However you cannot import with the input `(\\)` due to the implementation of the matchers of unite.vim. But better than totally impossible to import this operator or weird behaviour like `import Data.List ((\))`.
This pull request also cares for the `Closing bracket expected` error. Thus now you can
```
import Data.Functor ((<$))
  with inputs
  <$
  (<$)
  (<$   // ← Closing bracket expected
import Control.Applicative ((<$>))
  with inputs
  <$>
  (<$>)
  (<$>   // ← Closing bracket expected
```
When we input `(>>`, the candidates look like
```
❯ (>>
▸ Prelude (>>) :: Monad m => m a -> m b -> m b                                                                                                                                               
▸ Control.Monad (>>) :: Monad m => m a -> m b -> m b                                                                                                                                         
▸ Control.Monad.Instances (>>) :: Monad m => m a -> m b -> m b                                                                                                                               
▸ Prelude (>>=) :: Monad m => m a -> (a -> m b) -> m b                                                                                                                                       
▸ Control.Monad (>>=) :: Monad m => m a -> (a -> m b) -> m b                                                                                                                                 
▸ Control.Monad.Instances (>>=) :: Monad m => m a -> (a -> m b) -> m b                                                                                                                       
▸ Control.Category (>>>) :: Category cat => cat a b -> cat b c -> cat a c                                                                                                                    
▸ Control.Arrow (>>>) :: Category cat => cat a b -> cat b c -> cat a c                                                                                                                       
▸ Control.Arrow (>>^) :: Arrow a => a b c -> (c -> d) -> a b d                                                                                                                               
```
This is very cool, isn't it?