### PR TITLE
set required_pattern_length to one

### DIFF
--- a/autoload/unite/sources/haskellimport.vim
+++ b/autoload/unite/sources/haskellimport.vim
@@ -5,11 +5,11 @@ let s:unite_source = {
       \ 'name': 'haskellimport',
       \ 'max_candidates': 30,
       \ 'is_volatile': 1,
-      \ 'required_pattern_length': 2,
+      \ 'required_pattern_length': 1,
       \ }
 
 function! s:hoogle(input)
-  return s:remove_verbose(unite#util#system('hoogle --verbose "' . escape(a:input, '\"') . '"'))
+  return s:remove_verbose(unite#util#system('hoogle --verbose "' . escape(a:input, '\"') . '" | head -n 31'))
 endfunction
 
 function! s:unite_source.gather_candidates(args, context)


### PR DESCRIPTION
This pull request enables user to start filtering from the first character input. When it gets stuck when there are too much candidates so it uses the `head` command. For example, when we input `ma`, there are over 1000 candidates and the unite interface is stuck for a while.