### PR TITLE
remove keyword candidates

### DIFF
--- a/autoload/unite/sources/haskellimport.vim
+++ b/autoload/unite/sources/haskellimport.vim
@@ -34,7 +34,7 @@ endfunction
 function! s:remove_verbose(output)
   let l:output = substitute(a:output, '^.*= ANSWERS =\n', '', '')
   let l:output = substitute(l:output, '^No results found\n', '', '')
-  let l:output = substitute(l:output, 'package.\{-}\n', '', 'g')
+  let l:output = substitute(l:output, '\%(package\|keyword\).\{-}\n', '', 'g')
   let l:output = substitute(l:output, '  -- \(\a\+\(+\a\+\)*\)*', '', 'g')
   return l:output
 endfunction


### PR DESCRIPTION
This pull request removes keyword candidates. For example, filtering by `proc`, we see the candidate `keyword proc`, which we do not intend to import to the source code.