### PR TITLE
made it compatible with hoogle5

### DIFF
--- a/autoload/unite/sources/haskellimport.vim
+++ b/autoload/unite/sources/haskellimport.vim
@@ -36,7 +36,7 @@ endif
 function! s:hoogle(input) abort
   return s:system(
         \ 'hoogle --verbose --count 100 ' . shellescape(a:input)
-        \.' | sed -e "/^= ANSWERS =/d" -e "/^No results found/d" -e "/^keyword/d" -e "/^package/d" -e "s/  -- [+a-zA-Z]*$//g"'
+        \.' | sed -e "/^= ANSWERS =/d" -e "/^No results found/d" -e "/^keyword/d" -e "/^package/d" -e "/^Query:/d" -e "s/  -- [+a-zA-Z]*$//g"'
         \.' | head -n 30')
 endfunction
 


### PR DESCRIPTION
[hoogle 5.x](https://github.com/ndmitchell/hoogle) outputs in a slightly different format from that of hoogle ver 4.x. So I added a regexp to eliminate a non-result line.

I haven't tested by myself but I believe this would not affect existing hoogle 4.x users.