### PR TITLE
fix a bug in s:add_name()

### DIFF
--- a/autoload/haskellimport.vim
+++ b/autoload/haskellimport.vim
@@ -44,7 +44,7 @@ function! s:add_name(module, name) abort
   let import_re = '^import \+' . module_re
   call cursor(1, 1)
 
-  let newpos = search(import_re)
+  let newpos = search(import_re . '\([A-Za-z0-9_.]\)\@!')
   if !newpos
     return 0
   endif


### PR DESCRIPTION
Suppose if there is no 'import A.B' in the current buffer.
When unite-haskellimport tries to add 'import A.B (fun)',
it searches 'import A.B' first, but when there is already
'import A.B.C' or 'import A.BXYZ', search(import_re) will
unexpectedly find it first and unfortunately recognize it
as 'import A.B', which led to an unexpected behavior.

Here we introduce a "negative look ahead" that ensures
that 'import A.B' is not followed by '.' or other alphanumeric
characters so the matched line imports exactly 'A.B'.
